### PR TITLE
fix: Docker build compatibility with ROS 2 Jazzy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
 
 RUN apt-get update -qq \
     && apt-get install -y \
-        gz-${GZ_VERSION} \
         build-essential \
         python3-pip \
         ros-${ROS_DISTRO}-rcl-interfaces \
@@ -29,13 +28,17 @@ RUN apt-get update -qq \
         ros-${ROS_DISTRO}-vision-msgs \
         ros-${ROS_DISTRO}-actuator-msgs \
         ros-${ROS_DISTRO}-image-transport \
-        ros-${ROS_DISTRO}-nav2* \
-        ros-${ROS_DISTRO}-behaviortree-cpp-v3 \
+        ros-${ROS_DISTRO}-nav2-bringup \
+        ros-${ROS_DISTRO}-navigation2 \
+        ros-${ROS_DISTRO}-slam-toolbox \
+        ros-${ROS_DISTRO}-joint-state-publisher \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p ${COLCON_WS_SRC}\
-    && git clone https://github.com/alitekes1/ackermann-vehicle-gzsim-ros2.git ${COLCON_WS_SRC}/ackermann-vehicle-gzsim-ros2 \
-    && cd ${COLCON_WS}\
+RUN mkdir -p ${COLCON_WS_SRC}
+
+COPY . ${COLCON_WS_SRC}/ackermann-vehicle-gzsim-ros2
+
+RUN cd ${COLCON_WS}\
     && . /opt/ros/${ROS_DISTRO}/setup.sh\
     && colcon build
 

--- a/saye_bringup/package.xml
+++ b/saye_bringup/package.xml
@@ -10,15 +10,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>joint_state_publisher_gui</depend>
+  <depend>joint_state_publisher</depend>
   <depend>ros_gz</depend>
   <depend>sdformat_urdf</depend>
   <depend>saye_description</depend>
-  <!-- <depend>launch</depend> -->
-  <!-- <depend>launch_ros</depend> -->
   <depend>slam_toolbox</depend>
   <depend>nav2_bringup</depend>
-  <depend>explore_lite</depend>
   <depend>launch</depend>
   <depend>launch_ros</depend>
 

--- a/saye_control/CMakeLists.txt
+++ b/saye_control/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclpy REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(saye_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 include_directories(include)
@@ -26,10 +27,10 @@ install(
 )
 
 add_executable(main src/main.cpp)
-ament_target_dependencies(main rclcpp saye_msgs sensor_msgs)
+ament_target_dependencies(main rclcpp saye_msgs nav_msgs sensor_msgs)
 
 add_executable(client src/client.cpp)
-ament_target_dependencies(client rclcpp saye_msgs )
+ament_target_dependencies(client rclcpp saye_msgs nav_msgs)
 
 install(
   TARGETS 

--- a/saye_control/include/saye_control/control.hpp
+++ b/saye_control/include/saye_control/control.hpp
@@ -2,6 +2,7 @@
 #define CONTROL_HPP
 
 #include "rclcpp/rclcpp.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
 #include "saye_msgs/msg/map.hpp"
 #include "saye_msgs/srv/share_map.hpp"
 
@@ -92,7 +93,7 @@ void Control::sub_callback(saye_msgs::msg::Map::SharedPtr msg)
     // gazebo dan laser verisi alınacak ve işlenecek. merged map oluşturulacak.
     RCLCPP_ERROR(get_logger(), "data: %d", msg->header.stamp.sec);
 }
-void Control::service_callback(const saye_msgs::srv::ShareMap::Request::SharedPtr request, const saye_msgs::srv::ShareMap::Response::SharedPtr response)
+void Control::service_callback(const saye_msgs::srv::ShareMap::Request::SharedPtr /*request*/, const saye_msgs::srv::ShareMap::Response::SharedPtr response)
 {
     auto merged_map = nav_msgs::msg::OccupancyGrid(); // TODO: merged map paylaşılacak.
     response->custom_occupany_grid = merged_map;

--- a/saye_control/package.xml
+++ b/saye_control/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>saye_msgs</depend>
   <depend>nav2_msgs</depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
- Remove explore_lite dependency (not available in Jazzy, unused in code)
- Replace joint_state_publisher_gui with joint_state_publisher (not packaged for Jazzy)
- Replace nav2* wildcard and deprecated behaviortree-cpp-v3 with explicit packages in Dockerfile
- Add missing nav_msgs dependency to saye_control
- Fix unused parameter warning in control.hpp
- Use COPY instead of git clone in Dockerfile for local builds